### PR TITLE
Fix hardcoded room locations

### DIFF
--- a/ESPHome Configuration/esp360-default-1.yaml
+++ b/ESPHome Configuration/esp360-default-1.yaml
@@ -58,14 +58,14 @@ i2c:
 sensor:
   - platform: shtcx
     temperature:
-      name: "Living Room Temperature"
+      name: "Temperature"
       filters:
         - median: 
             window_size: 5
             send_every: 1
         - offset: -3.7
     humidity:
-      name: "Living Room Humidity"
+      name: "Humidity"
       filters:
         - median: 
             window_size: 5

--- a/ESPHome Configuration/esp360-default-2.yaml
+++ b/ESPHome Configuration/esp360-default-2.yaml
@@ -58,14 +58,14 @@ i2c:
 sensor:
   - platform: shtcx
     temperature:
-      name: "Living Room Temperature"
+      name: "Temperature"
       filters:
         - median: 
             window_size: 5
             send_every: 1
         - offset: -3.7
     humidity:
-      name: "Living Room Humidity"
+      name: "Humidity"
       filters:
         - median: 
             window_size: 5

--- a/ESPHome Configuration/my_configuration.yaml
+++ b/ESPHome Configuration/my_configuration.yaml
@@ -32,7 +32,7 @@ i2c:
 sensor:
   - platform: shtcx
     temperature:
-      name: "Living Room Temperature"
+      name: "Temperature"
       id: "Temperature"
       filters:
         - median: 
@@ -40,7 +40,7 @@ sensor:
             send_every: 1
         - offset: -3.7
     humidity:
-      name: "Living Room Humidity"
+      name: "Humidity"
       id: "Humidity"
       filters:
         - offset: +19.1  
@@ -220,7 +220,7 @@ switch:
 
 climate:
   - platform: coolix      
-    name: "Living Room AC"
+    name: "AC"
     transmitter_id: IR_TX
     sensor: Temperature
     receiver_id: IR_RX


### PR DESCRIPTION
fixes #3

Removes hardcoded "Living Room" from config file examples.